### PR TITLE
Handle additional root types for RelativePathSource

### DIFF
--- a/src/main/java/burp/ls/LogicalSourceFactory.java
+++ b/src/main/java/burp/ls/LogicalSourceFactory.java
@@ -248,8 +248,12 @@ public class LogicalSourceFactory {
 			String file = source.getProperty(RML.path).getLiteral().getString();
 
 			Resource root = source.getPropertyResourceValue(RML.root);
-			if (root != null && !RML.MappingDirectory.equals(root)) {
-				throw new RuntimeException("Root not yet implemented");
+			if (root != null) {
+				if (RML.MappingDirectory.equals(root)) return file;
+				if (RML.CurrentWorkingDirectory.equals(root))
+					return new File(new File(System.getProperty("user.dir")), file).getPath();
+				if (root.isLiteral()) return new File(root.asLiteral().getString(), file).getPath();
+				throw new RuntimeException("RelativePathSource specified root value is not supported. " + root);
 			}
 
 			// By default BURP treats it relative to mapping.

--- a/src/main/java/burp/vocabularies/RML.java
+++ b/src/main/java/burp/vocabularies/RML.java
@@ -18,6 +18,7 @@ public final class RML {
 	public static final Resource CSV = ResourceFactory.createResource(NS + "CSV");
 	public static final Resource JSONPath = ResourceFactory.createResource(NS + "JSONPath");
 	public static final Resource MappingDirectory = ResourceFactory.createResource(NS + "MappingDirectory");
+	public static final Resource CurrentWorkingDirectory = ResourceFactory.createResource(NS + "CurrentWorkingDirectory");
 	public static final Resource Namespace = ResourceFactory.createResource(NS + "Namespace");
 	public static final Resource RelativePathSource = ResourceFactory.createResource(NS + "RelativePathSource");
 	public static final Resource SQL2008Table = ResourceFactory.createResource(NS + "SQL2008Table");


### PR DESCRIPTION
Added support for resolving paths using `CurrentWorkingDirectory` and literal root values in `LogicalSourceFactory` when is of type `RelativePathSource`.