### PR TITLE
rml-io: Allow rml:SQLTable, rml:SQLQuery and D2RQ Source without driver, username, password.

### DIFF
--- a/src/main/java/burp/ls/LogicalSourceFactory.java
+++ b/src/main/java/burp/ls/LogicalSourceFactory.java
@@ -120,21 +120,39 @@ public class LogicalSourceFactory {
 		return source;
 	}
 
+    private static RDBSource createRDBSource(Resource sourceNode) {
+        Statement jdbcDSNStmt = sourceNode.getProperty(D2RQ.jdbcDSN);
+        if (jdbcDSNStmt == null) {
+            throw new RuntimeException("RDB source must have a d2rq:jdbcDSN property");
+        }
+        String jdbcDSN = jdbcDSNStmt.getLiteral().getString();
+
+        Statement jdbcDriverStmt = sourceNode.getProperty(D2RQ.jdbcDriver);
+        String jdbcDriver = jdbcDriverStmt != null ? jdbcDriverStmt.getLiteral().getString() : null;
+
+        Statement usernameStmt = sourceNode.getProperty(D2RQ.username);
+        String username = usernameStmt != null ? usernameStmt.getLiteral().getString() : null;
+
+        Statement passwordStmt = sourceNode.getProperty(D2RQ.password);
+        String password = passwordStmt != null ? passwordStmt.getLiteral().getString() : null;
+
+        RDBSource source = new RDBSource();
+        source.jdbcDSN = jdbcDSN;
+        source.jdbcDriver = jdbcDriver;
+        source.username = username;
+        source.password = password;
+        // If getNullValuesSource does not exist, use getNullValues or implement accordingly
+        source.nulls.addAll(getNullValuesSource(sourceNode));
+        return source;
+    }
+
 	public static LogicalSource createSQL2008TableSource(Resource ls, String mpath) {
 		Resource s = ls.getPropertyResourceValue(RML.source);
-		String jdbcDSN = s.getProperty(D2RQ.jdbcDSN).getLiteral().getString();
-		String jdbcDriver = s.getProperty(D2RQ.jdbcDriver).getLiteral().getString();
-		String username = s.getProperty(D2RQ.username).getLiteral().getString();
-		String password = s.getProperty(D2RQ.password).getLiteral().getString();
 
 		Statement t = ls.getProperty(RML.iterator);
 		String query = "(SELECT * FROM " + t.getLiteral() + ")";
 
-		RDBSource source = new RDBSource();
-		source.jdbcDSN = jdbcDSN;
-		source.jdbcDriver = jdbcDriver;
-		source.username = username;
-		source.password = password;
+		RDBSource source = createRDBSource(s);
 
 		// Apache jena "escapes" double quotes, so "Name" becomes \"Name\"
 		// which is internally stored as \\"Name\\". We thus need to remove
@@ -148,19 +166,11 @@ public class LogicalSourceFactory {
 
 	public static LogicalSource createSQL2008QuerySource(Resource ls, String mpath) {
 		Resource s = ls.getPropertyResourceValue(RML.source);
-		String jdbcDSN = s.getProperty(D2RQ.jdbcDSN).getLiteral().getString();
-		String jdbcDriver = s.getProperty(D2RQ.jdbcDriver).getLiteral().getString();
-		String username = s.getProperty(D2RQ.username).getLiteral().getString();
-		String password = s.getProperty(D2RQ.password).getLiteral().getString();
 
 		Statement t = ls.getProperty(RML.iterator);
 		String query = t.getLiteral().toString();
 
-		RDBSource source = new RDBSource();
-		source.jdbcDSN = jdbcDSN;
-		source.jdbcDriver = jdbcDriver;
-		source.username = username;
-		source.password = password;
+		RDBSource source = createRDBSource(s);
 
 		// Apache jena "escapes" double quotes, so "Name" becomes \"Name\"
 		// which is internally stored as \\"Name\\". We thus need to remove
@@ -319,20 +329,22 @@ public class LogicalSourceFactory {
 		}
 	}
 
-	private static List<Object> getNullValues(Resource ls) {
-		Resource r = ls.getPropertyResourceValue(RML.source);
-		List<Object> os = new ArrayList<>();
-		r.listProperties(RML.NULL).forEach(t -> {
-			if(t.getObject().isResource()) {
-				// WE ASSUME WE CAN HAVE RESOURCES AS NULL FOR
-				// SPARQL SOURCES
-				os.add(t.getObject().asResource());
-			} else {
-				os.add(t.getObject().asLiteral().getValue());
-			}
-		});
-		return os;
-	}
+    private static List<Object> getNullValuesSource(Resource sourceNode) {
+        List<Object> nullValues = new ArrayList<>();
+        sourceNode.listProperties(RML.NULL).forEach(stmt -> {
+            if (stmt.getObject().isResource()) {
+                // WE ASSUME WE CAN HAVE RESOURCES AS NULL FOR SPARQL SOURCES
+                nullValues.add(stmt.getObject().asResource());
+            } else {
+                nullValues.add(stmt.getObject().asLiteral().getValue());
+            }
+        });
+        return nullValues;
+    }
+
+    private static List<Object> getNullValues(Resource ls) {
+        return getNullValuesSource(ls.getPropertyResourceValue(RML.source));
+    }
 
 	// Generates prefix map from rml:namespace definitions
 	private static HashMap<String, String> getPrefixMap(Resource ls) {

--- a/src/main/java/burp/ls/RDBSource.java
+++ b/src/main/java/burp/ls/RDBSource.java
@@ -36,7 +36,11 @@ class RDBSource extends LogicalSource {
 			if (password != null && !"".equals(password))
 				props.setProperty("password", password);
 
-			Class.forName(jdbcDriver);
+            // This is not needed as they transitioned to Java Service Provider,
+            // but still, it will panic if the driver class is not found.
+            if (jdbcDriver != null && !jdbcDriver.isBlank())
+                Class.forName(jdbcDriver);
+
 			Connection connection = DriverManager.getConnection(jdbcDSN, props);
 			Statement statement = connection.createStatement();
 			final ResultSet resultset = statement.executeQuery(query);

--- a/src/main/java/burp/parse/Parse.java
+++ b/src/main/java/burp/parse/Parse.java
@@ -165,11 +165,11 @@ public class Parse {
 		if (referenceFormulation.hasProperty(RDF.type, RML.XPathReferenceFormulation))
 			return LogicalSourceFactory.createXMLSource(ls, mpath);
 
-		if (RML.SQL2008Table.equals(referenceFormulation))
-			return LogicalSourceFactory.createSQL2008TableSource(ls, mpath);
+        if (RML.SQL2008Table.equals(referenceFormulation) || RML.SQLTable.equals(referenceFormulation))
+            return LogicalSourceFactory.createSQL2008TableSource(ls, mpath);
 
-		if (RML.SQL2008Query.equals(referenceFormulation))
-			return LogicalSourceFactory.createSQL2008QuerySource(ls, mpath);
+        if (RML.SQL2008Query.equals(referenceFormulation) || RML.SQLQuery.equals(referenceFormulation))
+            return LogicalSourceFactory.createSQL2008QuerySource(ls, mpath);
 
 		if(RML.SPARQL_Results_CSV.equals(referenceFormulation))
 			return LogicalSourceFactory.createSPARQLSource(ls, mpath, false);

--- a/src/main/java/burp/vocabularies/RML.java
+++ b/src/main/java/burp/vocabularies/RML.java
@@ -22,7 +22,9 @@ public final class RML {
 	public static final Resource Namespace = ResourceFactory.createResource(NS + "Namespace");
 	public static final Resource RelativePathSource = ResourceFactory.createResource(NS + "RelativePathSource");
 	public static final Resource SQL2008Table = ResourceFactory.createResource(NS + "SQL2008Table");
+	public static final Resource SQLTable = ResourceFactory.createResource(NS + "SQLTable");
 	public static final Resource SQL2008Query = ResourceFactory.createResource(NS + "SQL2008Query");
+	public static final Resource SQLQuery = ResourceFactory.createResource(NS + "SQLQuery");
 	public static final Resource XPath = ResourceFactory.createResource(NS + "XPath");
 	public static final Resource XPathReferenceFormulation = ResourceFactory.createResource(NS + "XPathReferenceFormulation");
 


### PR DESCRIPTION
rml-io: Allow rml:SQLTable rml:SQLQuery  
rml-io: Allow D2RQ without driver, username, password. It may be useful for SQLite that does not require authentication.  
rml-io: jdbcDriver is optional as the Java Service Provider is used by default  


